### PR TITLE
Enhancement: Auto-assign STAND_NO for records with NULL or zero values

### DIFF
--- a/DesheTools/execution_scripts/UpdateUniqueStandNumbers.py
+++ b/DesheTools/execution_scripts/UpdateUniqueStandNumbers.py
@@ -1,12 +1,18 @@
+"""
+איך להגדיר את הכלי ב-ArcGIS Toolbox:
 
+    פרמטר ראשון – polygon_layer (שכבת פוליגונים)
+    פרמטר שני – assign_to_invalid (Boolean: כן/לא)
+        תיאור: "האם לעדכן גם עומדים עם ערך 0 או NULL?
+"""
 #----------------------------
-# Last updated: 29/04/2025 
+# Last updated: 13/07/2025 
 #----------------------------
 
 import arcpy
 from collections import defaultdict
 
-def update_stand_numbers(polygon_layer):
+def update_stand_numbers(polygon_layer, assign_to_invalid=True):
     helka_stands = defaultdict(list)
     changes = []
     warnings = []
@@ -14,10 +20,10 @@ def update_stand_numbers(polygon_layer):
     # שלב ראשון: איסוף כל הערכים הקיימים לפי HELKA
     with arcpy.da.SearchCursor(polygon_layer, ["HELKA", "STAND_NO"]) as cursor:
         for helka, stand_no in cursor:
-            if helka != 0 and stand_no is not None:
+            if helka != 0 and isinstance(stand_no, int) and stand_no != 0:
                 helka_stands[helka].append(stand_no)
 
-    # שלב שני: עדכון העומדים הכפולים
+    # שלב שני: עדכון עומדים
     with arcpy.da.UpdateCursor(polygon_layer, ["HELKA", "STAND_NO", "OID@"]) as cursor:
         counter_by_helka = defaultdict(int)
         existing_ids_by_helka = defaultdict(set)
@@ -30,8 +36,22 @@ def update_stand_numbers(polygon_layer):
                 warnings.append(f"OID {oid} has HELKA = 0 – no valid assignment.")
                 continue
 
+            is_invalid = stand_no is None or not isinstance(stand_no, int) or stand_no == 0
+
+            if is_invalid and assign_to_invalid:
+                max_existing = max(helka_stands[helka], default=0)
+                base = (max_existing // 10 + 1) * 10
+                new_no = base + counter_by_helka[helka]
+                counter_by_helka[helka] += 1
+
+                cursor.updateRow((helka, new_no, oid))
+                helka_stands[helka].append(new_no)
+                existing_ids_by_helka[helka].add(new_no)
+                changes.append((helka, f"OID {oid} (HELKA {helka}): {stand_no} → {new_no}"))
+                continue
+
             if stand_no in existing_ids_by_helka[helka]:
-                max_existing = max(helka_stands[helka])
+                max_existing = max(helka_stands[helka], default=0)
                 base = (max_existing // 10 + 1) * 10
                 new_no = base + counter_by_helka[helka]
                 counter_by_helka[helka] += 1
@@ -48,6 +68,7 @@ def update_stand_numbers(polygon_layer):
         arcpy.AddMessage("Changes made (sorted by HELKA):")
         for _, change_msg in changes:
             arcpy.AddMessage(change_msg)
+        arcpy.AddMessage(f"Total changes made: {len(changes)}")
     else:
         arcpy.AddMessage("No changes were necessary.")
 
@@ -55,8 +76,10 @@ def update_stand_numbers(polygon_layer):
         arcpy.AddWarning("Warnings:")
         for warning in warnings:
             arcpy.AddWarning(warning)
+        arcpy.AddWarning(f"Total warnings: {len(warnings)}")
 
 # הרצה
 if __name__ == "__main__":
     layer = arcpy.GetParameterAsText(0)
-    update_stand_numbers(layer)
+    assign_invalid_param = arcpy.GetParameterAsText(1).lower() == 'true'
+    update_stand_numbers(layer, assign_to_invalid=assign_invalid_param)


### PR DESCRIPTION
This update enhances the update_stand_numbers tool to support automatic assignment of STAND_NO values in cases where:

    HELKA is valid (non-zero)
    STAND_NO is either 0, None, or non-numeric

The new logic ensures that such records receive a unique STAND_NO based on the next available decade within the same HELKA.

Additionally, a new boolean parameter assign_to_invalid was introduced, allowing users to toggle this behavior on or off via the toolbox interface. ✅ Changes:

    Added detection and handling of invalid STAND_NO values (0, None, non-integer)
    Introduced assign_to_invalid parameter to control behavior
    Improved messaging and logging of changes and warnings

📌 Notes:

    When assign_to_invalid = False, the tool behaves as originally designed.
    All changes are backward-compatible