### PR TITLE
Fix: Display warning about -1 in Invasive Specie

### DIFF
--- a/smy2kkl2/smy2kkl2 - Copy/Scripts/‏‏smy_verification_param.py
+++ b/smy2kkl2/smy2kkl2 - Copy/Scripts/‏‏smy_verification_param.py
@@ -523,7 +523,7 @@ if __name__=='__main__':
                 if row[0] in bad_values:
                         cnt += 1
             if cnt > 0:
-                arcpy.AddMessage(f'\tThe {tab} table have {cnt} rows with values: {bad_values}' )
+                arcpy.AddWarning(f'\tThe {tab} table have {cnt} rows with values: {bad_values}' )
             else:
                 arcpy.AddMessage(f'\tThe {tab} table does not have "bad" values.')
 


### PR DESCRIPTION
טיפול בתקלה בתצוגת התראה על -1 בטבלת המינים הפולשים. ההתראה הוצגה כטקסט שחור (AddMessage) ולא התראה צהובה (AddWarning)