### PR TITLE
Update get_cov_type_name.txt

### DIFF
--- a/calculate_field_patches/get_cov_type_name.txt
+++ b/calculate_field_patches/get_cov_type_name.txt
@@ -65,5 +65,5 @@ def get_value_by_key(key):
     if key in code_to_text:
         return code_to_text[key]
     else:
-        return "Key not found"
+        return key
     


### PR DESCRIPTION
במקום שהפאצ' יחזיר "לא נמצא מין מתאים" שיניתי שהוא יחזיר את הקוד המקורי. כך במידה ומדובר בקוד מין שלא מוכר בהרכב מינים ארכיון נוכל לאחר מכן לשחזר אותו